### PR TITLE
npm publishに失敗する

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/octocat/my-other-repo.git"
+    "url": "https://github.com/yasshi2525/gamestick_sample"
   },
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
package.jsonのrepository指定値が不適切でpublishに失敗してしまう